### PR TITLE
Substituição do Termo de Ciência de Estágio

### DIFF
--- a/resources/views/estagios/partials/gerenciar_estagio.blade.php
+++ b/resources/views/estagios/partials/gerenciar_estagio.blade.php
@@ -93,12 +93,12 @@
                         <br>
                         <a href="/pdfs/termo/{{$estagio->id}}"target="_blank" >
                         <i class="fas fa-file-pdf"></i> </a>
-                        Gerar PDF do Termo de Ciência 
+                        Gerar PDF da Declaração de Responsabilidade
                     @else
                         <br>
                         <a href="/pdfs/renovacao/{{$estagio->id}}" target="_blank" >
                         <i class="fas fa-file-pdf"></i> </a>
-                        Gerar PDF do Termo de Ciência para Renovação
+                        Gerar PDF da Declaração de Responsabilidade para Renovação
                     @endif    
 
                     @if(($estagio->aditivos)->isNotEmpty())

--- a/resources/views/estagios/partials/rescisao.blade.php
+++ b/resources/views/estagios/partials/rescisao.blade.php
@@ -23,11 +23,11 @@
         @if(is_null($estagio->renovacao_parent_id))
             <a href="/pdfs/termo/{{$estagio->id}}.pdf" type="application/pdf" target="pdf-frame">
             <i class="fas fa-file-pdf"></i> </a>
-            Gerar PDF do Termo de Ciência 
+            Gerar PDF da Declaração de Responsabilidade
         @else
             <a href="/pdfs/renovacao/{{$estagio->id}}" target="_blank" >
             <i class="fas fa-file-pdf"></i> </a>
-            Gerar PDF do Termo de Ciência para Renovação
+            Gerar PDF da Declaração de Responsabilidade para Renovação
         @endif
     
     </div> 

--- a/resources/views/estagios/show.blade.php
+++ b/resources/views/estagios/show.blade.php
@@ -24,11 +24,11 @@
               @if(is_null($estagio->renovacao_parent_id))
                   <a href="/pdfs/termo/{{$estagio->id}}.pdf" type="application/pdf" target="pdf-frame">
                   <i class="fas fa-file-pdf"></i> </a>
-                  Gerar PDF do Termo de Ciência
+                  Gerar PDF da Declaração de Responsabilidade
               @else
                   <a href="/pdfs/renovacao/{{$estagio->id}}" target="_blank" >
                   <i class="fas fa-file-pdf"></i> </a>
-                  Gerar PDF do Termo de Ciência para Renovação
+                  Gerar PDF da Declaração de Responsabilidade para Renovação
               @endif
 
               @if(($estagio->aditivos)->isNotEmpty())

--- a/resources/views/pdfs/termo.blade.php
+++ b/resources/views/pdfs/termo.blade.php
@@ -3,30 +3,38 @@
 @section('content')
 
 <div style="width:100%; border-width: 1px; border-style: solid; border-color: #000; text-align: center; padding: 0px;">
-    <b>TERMO DE CIÊNCIA</b>
+    <b>DECLARAÇÃO DE RESPONSABILIDADE</b>
 </div>
 
-<br><br><br><br><br>
+<br><br>
 
 <div style="text-align: justify;">
-    <p style="text-indent : 3em;">Os documentos, impressos e assinados, devem ser entregues com pelo menos 10 dias úteis
+    <p style="text-indent : 1em;"> Declaro sob pena de responsabilidade, para fins de concessão / prorrogação de estágio, que estou ciente da impossibilidade de ser concedido estágio enquanto eu estiver vinculado(a) a outro estágio, e que este não ultrapasse a carga horária máxima permitida de 30h semanais / 6h diárias. </p>
+    <br>
+    <p style="text-indent : 1em;">Os documentos, impressos e assinados, devem ser entregues com pelo menos 10 dias úteis
         antes do início estágio.</p>
     <br>
-    <p style="text-indent : 3em;">É obrigatória a entrega de um relatório pessoal (digitado, datado, assinado e com no
+    <p style="text-indent : 1em;">É obrigatória a entrega de um relatório pessoal (digitado, datado, assinado e com no
         mínimo 7 linhas) no término desse estágio, relatando sua experiência no período.</p>
     <br>
-    <p style="text-indent : 3em; font-weight: bold">Uma via deste termo de Ciência deve ser entregue com o Termo de
+    <p style="text-indent : 1em; font-weight: bold">Uma via desta Declaração de Responsabilidade deve ser entregue com o Termo de
         Compromisso e Plano de Estágio.</p>
     <br>
-    <p>Ciência d{{ $estagio->artigo_definido }}
+    <p>Declaração d{{ $estagio->artigo_definido }}
         alun{{ $estagio->artigo_definido}}
         {{ $estagio->nome }}:</p>
 </div>
 
 <br><br>
 
+<div style="text-align: right;">
+    São Paulo, {{ \Carbon\Carbon::now()->locale('pt_BR')->isoFormat('D [de] MMMM [de] YYYY') }}
+</div>
+
 <div>
-    _______________________________________________<br>
+    <br><br><br>
+    _______________________________________________
+    <br>
     <b>{{ $estagio->nome }}</b><br>
     Nº USP: <b>{{ $estagio->numero_usp }}</b><br>
     <b>{{ $estagio->curso }}</b>


### PR DESCRIPTION
Solicitação de substituição do termo de ciência de estágio (a 1ª página do contrato), para Declaração de Responsabilidade seguindo a mesma formatação do Termo de Ciência dos contratos de estágio.